### PR TITLE
Fix releases link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 Binary packages for Mac OS X and Debian derivatives are available
 via [GitHub releases][rel].
 
-[rel]: https://github.com/solvespace/solvespace/releases
+[rel]: https://github.com/whitequark/solvespace/releases
 
 ### Other systems
 


### PR DESCRIPTION
The releases link pointed to the parent project (which doesn't have the files mentioned) instead of the whitequark fork.